### PR TITLE
Fix cell outputs if not natively supported by pandoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ['3.6', '3.7', '3.8', '3.9']
-        pandoc-version: ['2.7', '2.8', '2.9', '2.10', '2.11', '2.12']
+        pandoc-version: ['2.11', '2.12']
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - nbconvert >=5.5
     - notebook >=5.0
     - pandas
-    - pandoc >=2.7
+    - pandoc >=2.11
     - pandocfilters
     - pypandoc >=1.4
     - python

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -45,6 +45,7 @@ test:
     - pytest
     - pytest-cov
     - pytest-lazy-fixture
+    - sympy
   commands:
     - pytest --pyargs jupyter_docx_bundler
 

--- a/jupyter_docx_bundler/converters.py
+++ b/jupyter_docx_bundler/converters.py
@@ -193,7 +193,7 @@ def preprocess(content, path, handler=None):
                             source=output['data']['text/latex'],
                         ),
                     )
-                    cell['outputs'] = []
+                    del cell['outputs'][jj]
 
         # convert linked images to attachments
         linked_to_attachment_image(cell, path)

--- a/jupyter_docx_bundler/converters.py
+++ b/jupyter_docx_bundler/converters.py
@@ -194,6 +194,15 @@ def preprocess(content, path, handler=None):
                         ),
                     )
                     del cell['outputs'][jj]
+                elif 'data' in output and 'text/plain' in output['data'] and \
+                    'text/markdown' in output['data']:
+                    content['cells'].insert(
+                        ii + 1,
+                        nbformat.v4.new_markdown_cell(
+                            source=output['data']['text/markdown'],
+                        )
+                    )
+                    del cell['outputs'][jj]
 
         # convert linked images to attachments
         linked_to_attachment_image(cell, path)

--- a/jupyter_docx_bundler/converters.py
+++ b/jupyter_docx_bundler/converters.py
@@ -186,7 +186,7 @@ def preprocess(content, path, handler=None):
                             handler.log.warning(f'Conversion of pandas HTML-table failed : {e}')
                         else:
                             raise e
-                elif 'data' in output and 'text/latex' in output['data']:
+                elif 'data' in output and 'text/latex' in output['data'] and 'text/html' not in output['data']:
                     content['cells'].insert(
                         ii + 1,
                         nbformat.v4.new_markdown_cell(

--- a/jupyter_docx_bundler/converters.py
+++ b/jupyter_docx_bundler/converters.py
@@ -188,7 +188,8 @@ def preprocess(content, path, handler=None):
                         else:
                             raise e
                 # latex but not code cells (it write also a latex output)
-                elif 'data' in output and 'text/latex' in output['data'] and 'text/html' not in output['data']:
+                elif 'data' in output and 'text/latex' in output['data'] and \
+                        'text/html' not in output['data']:
                     content['cells'].insert(
                         ii + 1,
                         nbformat.v4.new_markdown_cell(
@@ -198,7 +199,7 @@ def preprocess(content, path, handler=None):
                     del cell['outputs'][jj]
                 # markdown
                 elif 'data' in output and 'text/plain' in output['data'] and \
-                    'text/markdown' in output['data']:
+                        'text/markdown' in output['data']:
                     content['cells'].insert(
                         ii + 1,
                         nbformat.v4.new_markdown_cell(

--- a/jupyter_docx_bundler/converters.py
+++ b/jupyter_docx_bundler/converters.py
@@ -170,6 +170,7 @@ def preprocess(content, path, handler=None):
         # process outputs
         if 'outputs' in cell:
             for jj, output in enumerate(cell['outputs']):
+                # pandas table
                 if 'data' in output and 'text/plain' in output['data'] and \
                         'text/html' in output['data'] and \
                         re.search('<table', output['data']['text/html']):
@@ -186,6 +187,7 @@ def preprocess(content, path, handler=None):
                             handler.log.warning(f'Conversion of pandas HTML-table failed : {e}')
                         else:
                             raise e
+                # latex but not code cells (it write also a latex output)
                 elif 'data' in output and 'text/latex' in output['data'] and 'text/html' not in output['data']:
                     content['cells'].insert(
                         ii + 1,
@@ -194,6 +196,7 @@ def preprocess(content, path, handler=None):
                         ),
                     )
                     del cell['outputs'][jj]
+                # markdown
                 elif 'data' in output and 'text/plain' in output['data'] and \
                     'text/markdown' in output['data']:
                     content['cells'].insert(

--- a/jupyter_docx_bundler/converters.py
+++ b/jupyter_docx_bundler/converters.py
@@ -186,6 +186,14 @@ def preprocess(content, path, handler=None):
                             handler.log.warning(f'Conversion of pandas HTML-table failed : {e}')
                         else:
                             raise e
+                elif 'data' in output and 'text/latex' in output['data']:
+                    content['cells'].insert(
+                        ii + 1,
+                        nbformat.v4.new_markdown_cell(
+                            source=output['data']['text/latex'],
+                        ),
+                    )
+                    cell['outputs'] = []
 
         # convert linked images to attachments
         linked_to_attachment_image(cell, path)

--- a/jupyter_docx_bundler/tests/conftest.py
+++ b/jupyter_docx_bundler/tests/conftest.py
@@ -576,7 +576,7 @@ def ipython_output_notebook(tmpdir, request):
                 }),
             )
         )
-        expected_pattern = '\$a \+ b\$'
+        expected_pattern = r'\$a \+ b\$'
     elif request.param == 'Code':
         nb.cells.append(
             nbformat.v4.new_code_cell(
@@ -588,7 +588,7 @@ def ipython_output_notebook(tmpdir, request):
                 }),
             )
         )
-        expected_pattern = '[\w`]*import this[\w`]*'
+        expected_pattern = r'[\w`]*import this[\w`]*'
 
     nb['metadata'].update({
         'path': f'{tmpdir}',

--- a/jupyter_docx_bundler/tests/conftest.py
+++ b/jupyter_docx_bundler/tests/conftest.py
@@ -552,7 +552,7 @@ def ipython_output_notebook(tmpdir, request):
                 }),
             )
         )
-        expected_output = '# Heading'
+        expected_pattern = '# Heading'
     elif request.param == 'LaTeX':
         nb.cells.append(
             nbformat.v4.new_code_cell(
@@ -564,7 +564,7 @@ def ipython_output_notebook(tmpdir, request):
                 }),
             )
         )
-        expected_output = '$a + b$'
+        expected_pattern = r'\$a \+ b\$'
     elif request.param == 'Math':
         nb.cells.append(
             nbformat.v4.new_code_cell(
@@ -576,7 +576,7 @@ def ipython_output_notebook(tmpdir, request):
                 }),
             )
         )
-        expected_output = '$a + b$'
+        expected_pattern = '\$a \+ b\$'
     elif request.param == 'Code':
         nb.cells.append(
             nbformat.v4.new_code_cell(
@@ -588,11 +588,11 @@ def ipython_output_notebook(tmpdir, request):
                 }),
             )
         )
-        expected_output = '`import this`'
+        expected_pattern = '[\w`]*import this[\w`]*'
 
     nb['metadata'].update({
         'path': f'{tmpdir}',
-        'expected_output': expected_output,
+        'expected_pattern': expected_pattern,
     })
 
     ep = ExecutePreprocessor()

--- a/jupyter_docx_bundler/tests/conftest.py
+++ b/jupyter_docx_bundler/tests/conftest.py
@@ -485,14 +485,51 @@ def pandas_html_table_notebook(tmpdir, request):
     return nb
 
 
+@pytest.fixture
+def math_in_output(tmpdir):
+    nb = nbformat.v4.new_notebook()
+
+    nb.cells.append(
+        nbformat.v4.new_code_cell(
+            source='\n'.join([
+                'from IPython.display import display',
+                'import sympy as sp',
+            ]),
+        )
+    )
+    nb.cells.append(
+        nbformat.v4.new_code_cell(
+            source='sp.var("a, b")'
+        )
+    )
+
+    nb.cells.append(
+        nbformat.v4.new_code_cell(
+            source='display(a/b**3)'
+        )
+    )
+
+    nb['metadata'].update({
+        'path': f'{tmpdir}',
+        'ncells': 1,
+    })
+
+    ep = ExecutePreprocessor()
+    ep.preprocess(nb, {'metadata': {'path': tmpdir}})
+
+    return nb
+
+
 @pytest.fixture(
     params=[
         lazy_fixture('math_with_space_notebook'),
         lazy_fixture('math_without_space_notebook'),
+        lazy_fixture('math_in_output'),
     ],
     ids=[
         'with_space',
-        'without_space'
+        'without_space',
+        'math_in_output',
     ]
 )
 def math_notebook(request):

--- a/jupyter_docx_bundler/tests/conftest.py
+++ b/jupyter_docx_bundler/tests/conftest.py
@@ -522,6 +522,87 @@ def math_in_output(tmpdir):
 
 @pytest.fixture(
     params=[
+        'Markdown',
+        'LaTeX',
+        'Math',
+        'Code',
+    ]
+)
+def ipython_output_notebook(tmpdir, request):
+    nb = nbformat.v4.new_notebook()
+
+    nb.cells.append(
+        nbformat.v4.new_code_cell(
+            source='from IPython import display',
+            metadata=nbformat.notebooknode.NotebookNode({
+                'tags': [
+                    'nbconvert-remove-input',
+                ],
+            }),
+        ),
+    )
+    if request.param == 'Markdown':
+        nb.cells.append(
+            nbformat.v4.new_code_cell(
+                source='display.Markdown("# Heading")',
+                metadata=nbformat.notebooknode.NotebookNode({
+                    'tags': [
+                        'nbconvert-remove-input',
+                    ],
+                }),
+            )
+        )
+        expected_output = '# Heading'
+    elif request.param == 'LaTeX':
+        nb.cells.append(
+            nbformat.v4.new_code_cell(
+                source='display.Latex("$a + b$")',
+                metadata=nbformat.notebooknode.NotebookNode({
+                    'tags': [
+                        'nbconvert-remove-input',
+                    ],
+                }),
+            )
+        )
+        expected_output = '$a + b$'
+    elif request.param == 'Math':
+        nb.cells.append(
+            nbformat.v4.new_code_cell(
+                source='display.Math("a + b")',
+                metadata=nbformat.notebooknode.NotebookNode({
+                    'tags': [
+                        'nbconvert-remove-input',
+                    ],
+                }),
+            )
+        )
+        expected_output = '$a + b$'
+    elif request.param == 'Code':
+        nb.cells.append(
+            nbformat.v4.new_code_cell(
+                source='display.Code("import this")',
+                metadata=nbformat.notebooknode.NotebookNode({
+                    'tags': [
+                        'nbconvert-remove-input',
+                    ],
+                }),
+            )
+        )
+        expected_output = '`import this`'
+
+    nb['metadata'].update({
+        'path': f'{tmpdir}',
+        'expected_output': expected_output,
+    })
+
+    ep = ExecutePreprocessor()
+    ep.preprocess(nb, {'metadata': {'path': tmpdir}})
+
+    return nb
+
+
+@pytest.fixture(
+    params=[
         lazy_fixture('math_with_space_notebook'),
         lazy_fixture('math_without_space_notebook'),
         lazy_fixture('math_in_output'),

--- a/jupyter_docx_bundler/tests/test_converters.py
+++ b/jupyter_docx_bundler/tests/test_converters.py
@@ -256,4 +256,4 @@ def test_ipython_output(tmpdir, ipython_output_notebook):
     # replace newlines
     lines = [line.replace('\n', '') for line in lines]
     assert len(lines) == 1
-    assert lines[0] == ipython_output_notebook['metadata']['expected_output']
+    assert re.search(ipython_output_notebook['metadata']['expected_pattern'], lines[0])

--- a/jupyter_docx_bundler/tests/test_converters.py
+++ b/jupyter_docx_bundler/tests/test_converters.py
@@ -230,9 +230,6 @@ def test_pandas_html_table(tmpdir, pandas_html_table_notebook):
 
 
 def test_ipython_output(tmpdir, ipython_output_notebook):
-    # extract the output of the last cell in the notebook, we need to check against that
-    outputs = ipython_output_notebook['cells'][-1]['outputs'][-1]['data']
-
     # convert notebook to docx
     docxbytes = converters.notebookcontent_to_docxbytes(
         ipython_output_notebook,

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,3 +7,4 @@ pillow >= 6.0.0
 pytest
 pytest-cov
 pytest-lazy-fixture
+sympy

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
             'pytest',
             'pytest-cov',
             'pytest-lazy-fixture',
+            'sympy',
         ],
     },
     install_requires=[


### PR DESCRIPTION
**New feature/Bug fix description**

Pandoc does not support all types of outputs of cells yet. So we convert them to compatible types.

**Related issues**

Close #73 

**Checklist**

- [x] Tests have passed
- [x] New code is covered with tests
